### PR TITLE
abort editing feature

### DIFF
--- a/jquery.editable.js
+++ b/jquery.editable.js
@@ -1,13 +1,12 @@
 /*
  *
- * jQuery Editables 1.0.1 (jimk branch)
+ * jQuery Editables 1.0.1.3 (jimk branch)
  * 
  * Date: Aug 11 2012
  * Source: www.tectual.com.au, www.arashkarimzadeh.com
  * Author: Arash Karimzadeh (arash@tectual.com.au)
  * Contributors: Jim Kinsman (relipse@gmail.com)
  * 
- *
  * Copyright (c) 2012 Tectual Pty. Ltd.
  * http://www.opensource.org/licenses/mit-license.php
  *
@@ -42,11 +41,15 @@ $.fn.editables = function(options, arg2){
               if(bf==false) return;
               t.hide();
               $this.show();
+            
               if (bf === 'abort'){
                  if (t.data('oldvalue') !== undefined){
                     t.val(t.data('oldvalue'));
                  }
                  return; //do not call onFreeze, because we aborted freeze
+              }else if (t.data('oldvalue') == t.val()){
+                 //value never changed
+                 return;
               }
               t.trigger('onFreeze');
          },

--- a/jquery.editable.js
+++ b/jquery.editable.js
@@ -5,17 +5,27 @@
  * Date: Aug 11 2012
  * Source: www.tectual.com.au, www.arashkarimzadeh.com
  * Author: Arash Karimzadeh (arash@tectual.com.au)
+ * Contributors: Jim Kinsman (relipse@gmail.com)
+ * 
  *
  * Copyright (c) 2012 Tectual Pty. Ltd.
  * http://www.opensource.org/licenses/mit-license.php
  *
- * 27-Jan-2013 JimK: Added beforeFreeze abort option to 
- *     abort editing (using esc key would be a common implementation)
- *     Stored old data in data-oldvalue="foobar"
  */
 (function($){
  
-$.fn.editables = function(options){
+$.fn.editables = function(options, arg2){
+  
+  //if we already have an existing editable plugin, go ahead and call a method 
+  //@see this.methods = { ...
+  if (typeof(options) == 'string'){
+     $('[data-type=editable]', this).each(function(){
+         if (typeof(this.methods[options]) == 'function'){
+            this.methods[options].call(arg2);
+         }
+     });
+     return;
+  }
   
   var opts = $.extend( {}, $.fn.editables.options, options );
   
@@ -25,32 +35,37 @@ $.fn.editables = function(options){
   $('[data-type=editable]', this).each(
     function(){
       var $this = $(this);
-      var fn = function(ev){
-        var t = $($this.data('for'));
-        var bf = opts.beforeFreeze.call(t, $this, ev);
-        if(bf==false) return;
-        t.hide();
-        $this.show();
-        if (bf === 'abort'){
-           if (t.data('oldvalue') !== undefined){
-              t.val(t.data('oldvalue'));
-           }
-           return; //do not call onFreeze, because we aborted freeze
-        }
-        t.trigger('onFreeze');
+      this.methods = {
+         freeze : function(ev) {
+              var t = $($this.data('for'));
+              var bf = opts.beforeFreeze.call(t, $this, ev);
+              if(bf==false) return;
+              t.hide();
+              $this.show();
+              if (bf === 'abort'){
+                 if (t.data('oldvalue') !== undefined){
+                    t.val(t.data('oldvalue'));
+                 }
+                 return; //do not call onFreeze, because we aborted freeze
+              }
+              t.trigger('onFreeze');
+         },
+         edit : function(ev){
+              var t = $($this.data('for'));
+              if(opts.beforeEdit.call($this, t, ev)==false) return;
+              $this.hide();
+              t.show().focus();
+              t.data('oldvalue', t.val());
+              $this.trigger('onEdit');
+         }
       };
+      
+      var fn = this.methods.freeze;
       var evs= {};
       $.each( opts.freezeOn, function(){ evs[this] = fn; } );
       $($this.data('for')).hide().bind('onFreeze', opts.onFreeze).bind(evs);
       
-      var fn = function(ev){
-        var t = $($this.data('for'));
-        if(opts.beforeEdit.call($this, t, ev)==false) return;
-        $this.hide();
-        t.show().focus();
-        t.data('oldvalue', t.val());
-        $this.trigger('onEdit');
-      }
+      var fn = this.methods.edit;
       var evs = {};
       $.each( opts.editOn, function(){ evs[this] = fn; } );
       $this.bind('onEdit', opts.onEdit).bind(evs);
@@ -68,5 +83,3 @@ $.fn.editables.options = {
 }
 
 })(jQuery);
-
-

--- a/jquery.editable.js
+++ b/jquery.editable.js
@@ -1,6 +1,6 @@
 /*
  *
- * jQuery Editables 1.0.1
+ * jQuery Editables 1.0.1 (jimk branch)
  * 
  * Date: Aug 11 2012
  * Source: www.tectual.com.au, www.arashkarimzadeh.com
@@ -9,6 +9,9 @@
  * Copyright (c) 2012 Tectual Pty. Ltd.
  * http://www.opensource.org/licenses/mit-license.php
  *
+ * 27-Jan-2013 JimK: Added beforeFreeze abort option to 
+ *     abort editing (using esc key would be a common implementation)
+ *     Stored old data in data-oldvalue="foobar"
  */
 (function($){
  
@@ -24,9 +27,16 @@ $.fn.editables = function(options){
       var $this = $(this);
       var fn = function(ev){
         var t = $($this.data('for'));
-        if(opts.beforeFreeze.call(t, $this, ev)==false) return;
+        var bf = opts.beforeFreeze.call(t, $this, ev);
+        if(bf==false) return;
         t.hide();
         $this.show();
+        if (bf === 'abort'){
+           if (t.data('oldvalue') !== undefined){
+              t.val(t.data('oldvalue'));
+           }
+           return; //do not call onFreeze, because we aborted freeze
+        }
         t.trigger('onFreeze');
       };
       var evs= {};
@@ -38,6 +48,7 @@ $.fn.editables = function(options){
         if(opts.beforeEdit.call($this, t, ev)==false) return;
         $this.hide();
         t.show().focus();
+        t.data('oldvalue', t.val());
         $this.trigger('onEdit');
       }
       var evs = {};


### PR DESCRIPTION
user can now cancel request and it won't call onFreeze() which normally means successful 
also stored old-value

also now the user can do $().editables('edit') to show the edit box
